### PR TITLE
Quick fix for mobile device styles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,9 +43,9 @@
 <div class="container">
   <div>
     <header role="banner">
-       <div style="float:right;">
-         <a href="https://github.com/{{ site.org_name }}/{{ site.repo_name }}/issues/" style="color: white;" class="button">Discuss</a> | 
-         <a href="https://github.com/{{ site.org_name }}/{{ site.repo_name }}/edit/{{ site.branch }}/{{ page.path }}" class="button" style="color: white;">Edit</a> | 
+       <div class="header_menu">
+         <a href="https://github.com/{{ site.org_name }}/{{ site.repo_name }}/issues/" style="color: white;" class="button">Discuss</a> |
+         <a href="https://github.com/{{ site.org_name }}/{{ site.repo_name }}/edit/{{ site.branch }}/{{ page.path }}" class="button" style="color: white;">Edit</a> |
          <a href="{{ site.baseurl }}/SourceCodePolicy.pdf" class="button" style="color: white;">View PDF</a>
        </div>
       <h1>
@@ -53,7 +53,7 @@
       </h1>
     </header>
   </div>
- 
+
   <div class="wrap content">
     {% include sidebar.html %}
 

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -14,7 +14,7 @@ $link-active:         #002d72;
 $link-hover:          #7eb8dd;
 
 $header-height:        80px;
-$header-height-mobile: 65px;
+$header-height-mobile: 95px;
 
 // Fonts
 $serif:               "Merriweather", "Georgia", "Times New Roman", serif;
@@ -104,7 +104,6 @@ header {
     color: $white;
 
     position: fixed;
-    height: $header-height;
     width: 100%;
 
     h1 {
@@ -124,16 +123,20 @@ header {
     }
 }
 
-aside {
-  @include span-columns(3.25);
-  margin-top: $header-height;
-}
-
 article {
   @include shift(0.25);
   @include span-columns(8);
   margin-bottom: 20px;
   margin-top: $header-height;
+  overflow: hidden; // accomdate long link text on mobile devices
+}
+
+@media screen and (min-width: 600px) {
+
+  .header_menu {
+    float: right;
+  }
+
 }
 
 @media screen and (max-width: 600px) {


### PR DESCRIPTION
Currently https://sourcecode.cio.gov has a few broken styles on mobile devices. This fixes two things:
- Removes the float from the header navigation menu on mobile devices
- Hides content that overflows the `article` container, which was happening with long link URLs

Very excited to see this policy!
