### PR TITLE
Add gitignore for common Jekyll/Sass files and folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+_site/
+.sass-cache/
+.jekyll-metadata
+Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 _site/
 .sass-cache/
 .jekyll-metadata
-Gemfile.lock


### PR DESCRIPTION
This PR adds a .gitignore file to keep anyone building the site locally from accidentally committing unnecessary auto-generated files from Jekyll (i.e. `_site`), Sass (i.e. `.sass-cache`) ~~and Ruby (i.e. `Gemfile.lock`)~~.
