### PR TITLE
Add baseurl argument to the README for running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ bundle install
 And run the site with Jekyll:
 
 ```
-bundle exec jekyll serve --watch
+bundle exec jekyll serve --watch --baseurl ''
 ```
 
 If all goes well, visit the site at `http://localhost:4000`.


### PR DESCRIPTION
With the current `baseurl` configuration in `_config.yml`, running the site locally will result in Jekyll trying to answer at `http://127.0.0.1:4000https://sourcecode.cio.gov/`. 

This PR adds the argument `--baseurl ''` to the command to run Jekyll locally in the  README.
