### PR TITLE
Fix bug where superscript elements float over header banner

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -106,6 +106,7 @@ header {
     position: fixed;
     height: $header-height;
     width: 100%;
+    z-index: 1;
 
     h1 {
         margin: 0;


### PR DESCRIPTION
![screen shot 2016-03-11 at 10 37 11 am](https://cloud.githubusercontent.com/assets/5697474/13708799/23761764-e776-11e5-87cf-75318e425df9.png)

Two obvious simple fixes:
1. give `header` a higher z-index.
2. give `sup` a negative z-index.

I went for option 1.
