### PR TITLE
Prevent citation links from scrolling on top of header

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -104,6 +104,7 @@ header {
     color: $white;
 
     position: fixed;
+    z-index: 10;
     height: $header-height;
     width: 100%;
 


### PR DESCRIPTION
When you scroll, citations currently appear over the header. Added a z-index to the header so it floats above everything.
