### PR TITLE
Fixing link to M-16-21 pdf

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,7 +46,7 @@
        <div class="header_menu">
          <a href="https://github.com/{{ site.org_name }}/{{ site.repo_name }}/issues/" style="color: white;" class="button">Discuss</a> |
          <a href="https://github.com/{{ site.org_name }}/{{ site.repo_name }}/edit/{{ site.branch }}/{{ page.path }}" class="button" style="color: white;">Edit</a> |
-         <a href="https://www.whitehouse.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf" class="button" style="color: white;">View PDF of Policy</a>
+         <a href="https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2016/m_16_21.pdf" class="button" style="color: white;">View PDF of Policy</a>
        </div>
       <h1>
         <a href="/">{{ site.name }}</a>


### PR DESCRIPTION
Changing "View PDF of Policy" to its new location, moved to https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2016/m_16_21.pdf

[Existing pull request](https://github.com/WhiteHouse/source-code-policy/pull/269) points to obamawhitehouse.archives, this points to location on current whitehouse.gov